### PR TITLE
Round-trip with hjson-js

### DIFF
--- a/hjson/__init__.py
+++ b/hjson/__init__.py
@@ -426,7 +426,7 @@ _default_json_encoder = JSONEncoder(
     int_as_string_bitcount=None,
 )
 
-def dumpJSON(obj, fp, skipkeys=False, ensure_ascii=True, check_circular=True,
+def dumpJSON(obj, fp, skipkeys=False, ensure_ascii=False, check_circular=True,
          cls=None, indent=None, separators=None,
          encoding='utf-8', default=None, use_decimal=True,
          namedtuple_as_object=True, tuple_as_array=True,


### PR DESCRIPTION
Hi, Many thanks again for this project!

This PR must not be merged and is intended as a general discussion:
should we turn `ensure_ascii` to `False` by default when encoding `HJSON` into `JSON`?

I noticed when using the python implementation that `hjson -j` writes any non ascii character gets escaped as a unicode character.
This is the hack I have done to keep `é` as is instead of turning it into `\u00E9`
Once that is done, I get a perfect round-trip to the original `JSON` generated by nodejs.

Let me know.
Cheers!