### PR TITLE
Change from scripts to entry_points in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,11 @@ def run_setup():
         license="MIT License",
         packages=['hjson', 'hjson.tests'],
         platforms=['any'],
-        scripts=['bin/hjson', 'bin/hjson.cmd',],
+        entry_points = {
+            'console_scripts': [
+                'hjson = hjson.tool:main',
+            ],
+        },
         **kw)
 
 run_setup()


### PR DESCRIPTION
Hi there,

I'm adding a conda-forge package for `hjson-py` (available at https://anaconda.org/conda-forge/hjson-py) and it was recommended at https://github.com/conda-forge/staged-recipes/pull/19022#discussion_r884137576 to change the `scripts` section in setup.py to `entry_points: console_scripts` instead so that noarch can be used. Here's a patch for this.

Fixes #20, fixes #22

References:
- https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#console-scripts
- https://stackoverflow.com/questions/18787036/difference-between-entry-points-console-scripts-and-scripts-in-setup-py

