### PR TITLE
Use entry_points instead of scripts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include *.py
 include *.txt
 include *.rst
-include bin/*
 include MANIFEST.in
 prune \#*

--- a/bin/hjson
+++ b/bin/hjson
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-python -m hjson.tool "$@"

--- a/bin/hjson.cmd
+++ b/bin/hjson.cmd
@@ -1,1 +1,0 @@
-@python -m hjson.tool %*

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,12 @@ def run_setup():
         license="MIT License",
         packages=['hjson', 'hjson.tests'],
         platforms=['any'],
-        scripts=['bin/hjson', 'bin/hjson.cmd',],
-        **kw)
+        entry_points={
+            "console_scripts": [
+                "hjson = hjson.tool:main",
+            ],
+        },
+        **kw,
+    )
 
 run_setup()


### PR DESCRIPTION
Switches to setuptools entry_points instead of scripts as recommended in the [Packaging Guide](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#scripts)

Fixes:
https://github.com/hjson/hjson-py/issues/20

Partially fixes:
https://github.com/hjson/hjson-py/issues/22

Related:
https://github.com/hjson/hjson-py/pull/29